### PR TITLE
[Feature] 카카오 로그인 완료 및 token 전역 관리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,19 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
         "@types/react-router-dom": "^5.3.3",
-        "axios": "^1.7.4",
+        "axios": "^1.7.7",
         "date-fns": "^4.1.0",
         "react": "^18.3.1",
         "react-calendar": "^5.0.0",
+        "react-cookie": "^7.2.2",
         "react-dom": "^18.3.1",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.24.1",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.11",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^5.0.1"
       },
       "devDependencies": {
         "@types/node": "^20.12.12",
@@ -4049,6 +4051,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
@@ -4106,6 +4113,15 @@
       "version": "4.7.11",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
@@ -5236,9 +5252,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -9184,6 +9200,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -15012,6 +15041,19 @@
         }
       }
     },
+    "node_modules/react-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.2.2.tgz",
+      "integrity": "sha512-e+hi6axHcw9VODoeVu8WyMWyoosa1pzpyjfvrLdF7CexfU+WSGZdDuRfHa4RJgTpfv3ZjdIpHE14HpYBieHFhg==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -17465,6 +17507,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/universal-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.2.tgz",
+      "integrity": "sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -18642,6 +18701,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+      "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,17 +8,19 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
     "@types/react-router-dom": "^5.3.3",
-    "axios": "^1.7.4",
+    "axios": "^1.7.7",
     "date-fns": "^4.1.0",
     "react": "^18.3.1",
     "react-calendar": "^5.0.0",
+    "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.24.1",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.11",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import LoginPage from 'pages/login';
+import LoginPage from 'pages/login/login';
+import LoginSuccessPage from 'pages/login/loginSuccess';
 import JoinPage from 'pages/join';
 import HomePage from 'pages/home';
 import CommunityPage from 'pages/community';
@@ -17,6 +18,7 @@ function App() {
         <Routes>
           <Route path="/" element={<LoginPage />} />
           <Route path="/join" element={<JoinPage />} />
+          <Route path="/success" element={<LoginSuccessPage />} />
           <Route path="/home" element={<HomePage />} />
           <Route path="/community" element={<CommunityPage />} />
           <Route path="/community/:postId" element={<CommunityDetailPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
         <Routes>
           <Route path="/" element={<LoginPage />} />
           <Route path="/join" element={<JoinPage />} />
-          <Route path="/success" element={<LoginSuccessPage />} />
+          <Route path="/login/success" element={<LoginSuccessPage />} />
           <Route path="/home" element={<HomePage />} />
           <Route path="/community" element={<CommunityPage />} />
           <Route path="/community/:postId" element={<CommunityDetailPage />} />

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,1 @@
+import client from './client';

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,1 +1,9 @@
 import client from './client';
+
+export const refreshToken = async (refreshToken: string) => {
+  const response = await client.post('/auth/refresh', {
+    refreshToken: refreshToken,
+  });
+
+  return response.data;
+};

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+  withCredentials: true,
+});
+
+export default client;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,29 @@
+import { refreshToken } from 'apis/auth';
+import { ReactNode, useEffect } from 'react';
+import { useCookies } from 'react-cookie';
+import { useMutation } from 'react-query';
+import { useUserStore } from 'store/user';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  const [cookies] = useCookies(['refreshToken']);
+  const setAccessToken = useUserStore((state) => state.setAccessToken);
+
+  const refreshTokenMutation = useMutation(refreshToken, {
+    onSuccess: (data) => {
+      setAccessToken(data.accessToken);
+    },
+    onError: (e) => {
+      console.log(e);
+    },
+  });
+
+  useEffect(() => {
+    refreshTokenMutation.mutate(cookies.refreshToken);
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import reportWebVitals from './reportWebVitals';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { CookiesProvider } from 'react-cookie';
 import '../src/styles/globals.css';
+import Layout from 'components/Layout';
 
 const queryClient = new QueryClient();
 const root = ReactDOM.createRoot(
@@ -14,7 +15,9 @@ root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <CookiesProvider>
-        <App />
+        <Layout>
+          <App />
+        </Layout>
       </CookiesProvider>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,21 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { CookiesProvider } from 'react-cookie';
 import '../src/styles/globals.css';
 
+const queryClient = new QueryClient();
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <CookiesProvider>
+        <App />
+      </CookiesProvider>
+    </QueryClientProvider>
   </React.StrictMode>,
 );
 

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import { Desc_150_reg, Chip_button_med } from 'styles/typography';
-import { ReactComponent as Logo } from '../assets/icons/logo.svg';
-import { ReactComponent as KakaoIcon } from '../assets/icons/kakao.svg';
-import BackgroundImage from '../assets/images/login.svg';
+import { ReactComponent as Logo } from '../../assets/icons/logo.svg';
+import { ReactComponent as KakaoIcon } from '../../assets/icons/kakao.svg';
+import BackgroundImage from '../../assets/images/login.svg';
 
 /*height를 부모요소에서 61px를 뺀 값으로 해서 Detail에서 margin-top: 61px를 했을 때, 
 상단 마진을 줘서 요소가 부모 요소의 height를 초과해 잘리는 문제를 해결함*/
@@ -54,7 +54,7 @@ const Icon = styled.div`
 `;
 
 export default function LoginPage() {
-  const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REACT_APP_KAKAO_API_KEY}&redirect_uri=${process.env.REACT_APP_REDIRECT_URI}/login/oauth2/code/kakao&response_type=code`;
+  const KAKAO_AUTH_URL = `http://ec2-13-125-157-219.ap-northeast-2.compute.amazonaws.com:8080/oauth2/authorization/kakao`;
 
   return (
     <Container>

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -54,7 +54,7 @@ const Icon = styled.div`
 `;
 
 export default function LoginPage() {
-  const KAKAO_AUTH_URL = `http://ec2-13-125-157-219.ap-northeast-2.compute.amazonaws.com:8080/oauth2/authorization/kakao`;
+  const KAKAO_AUTH_URL = `${process.env.REACT_APP_API_URL}/oauth2/authorization/kakao`;
 
   return (
     <Container>

--- a/src/pages/login/loginSuccess.tsx
+++ b/src/pages/login/loginSuccess.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useCookies } from 'react-cookie';
+import { useUserStore } from 'store/user';
 
 export default function loginSuccess() {
   const location = useLocation();
@@ -9,22 +10,26 @@ export default function loginSuccess() {
 
   const queryParams = new URLSearchParams(location.search);
   const refreshToken = queryParams.get('refreshToken');
+  const accessToken = queryParams.get('accessToken');
   const isNewMember = queryParams.get('isNewMember');
 
+  const setAccessToken = useUserStore((state) => state.setAccessToken);
+  const setRefreshToken = useUserStore((state) => state.setRefreshToken);
+
   useEffect(() => {
-    if (isNewMember == 'true') {
-      navigate('/join');
-    } else {
-      //쿠키로 설정
-      setCookies('refreshToken', refreshToken, {
-        sameSite: 'strict',
-        path: '/home',
-      });
-      setCookies('refreshToken', refreshToken, {
-        sameSite: 'strict',
-        path: '/',
-      });
-      navigate('/home');
+    if (refreshToken !== null && accessToken !== null && isNewMember !== null) {
+      if (isNewMember == 'true') {
+        navigate('/join');
+      } else {
+        //쿠키로 설정
+        setAccessToken(accessToken);
+        setRefreshToken(refreshToken);
+        setCookies('refreshToken', refreshToken, {
+          sameSite: 'strict',
+          path: '/',
+        });
+        navigate('/home');
+      }
     }
   }, []);
 

--- a/src/pages/login/loginSuccess.tsx
+++ b/src/pages/login/loginSuccess.tsx
@@ -1,0 +1,3 @@
+export default function loginSuccess() {
+  return <div></div>;
+}

--- a/src/pages/login/loginSuccess.tsx
+++ b/src/pages/login/loginSuccess.tsx
@@ -1,3 +1,32 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useCookies } from 'react-cookie';
+
 export default function loginSuccess() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [cookies, setCookies] = useCookies();
+
+  const queryParams = new URLSearchParams(location.search);
+  const refreshToken = queryParams.get('refreshToken');
+  const isNewMember = queryParams.get('isNewMember');
+
+  useEffect(() => {
+    if (isNewMember == 'true') {
+      navigate('/join');
+    } else {
+      //쿠키로 설정
+      setCookies('refreshToken', refreshToken, {
+        sameSite: 'strict',
+        path: '/home',
+      });
+      setCookies('refreshToken', refreshToken, {
+        sameSite: 'strict',
+        path: '/',
+      });
+      navigate('/home');
+    }
+  }, []);
+
   return <div></div>;
 }

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -1,0 +1,3 @@
+export default function MainPage() {
+  return <></>;
+}

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface UserStoreProps {
+  accessToken: string;
+  refreshToken: string;
+  setAccessToken: (accessToken: string) => void;
+  setRefreshToken: (refreshToken: string) => void;
+}
+
+export const useUserStore = create<UserStoreProps>((set) => ({
+  accessToken: '',
+  refreshToken: '',
+  setAccessToken: (newAccessToken) => set({ accessToken: newAccessToken }),
+  setRefreshToken: (newRefreshToken) => set({ refreshToken: newRefreshToken }),
+}));


### PR DESCRIPTION
## 📌 관련 이슈

#2 - 로그인 페이지

## 📚 작업 내용

- 카카오 로그인 완료
- 첫 회원가입 시, /join 페이지, 아닐 시, /home 페이지로 이동
- 로그인 시, refreshToken 쿠키에 저장
- 로그인 시, refreshToken, accessToken 전역 관리(zustand)

<!--
### Q. 고민1
뭐시기 뭐시기
-->

## 비고

- 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
